### PR TITLE
Fixes and enhancements to GrabDrop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+
+TaleSpireGrabDropPlugin/obj/Debug/GrabDropPlugin.csproj.CoreCompileInputs.cache
+*.cache
+TaleSpireGrabDropPlugin/obj/Debug/TemporaryGeneratedFile_036C0B5B-1481-4323-8D20-8F5ADCB23D92.cs
+TaleSpireGrabDropPlugin/obj/Debug/TemporaryGeneratedFile_5937a670-0e60-4077-877b-f7221da3dda1.cs
+TaleSpireGrabDropPlugin/obj/Debug/TemporaryGeneratedFile_E7A71F73-0F8D-4B9B-B56E-8E70B10BC5D3.cs
+.vs/TaleSpireGrabDropPlugin/v15/Server/sqlite3/storage.ide-wal
+.vs/TaleSpireGrabDropPlugin/v15/Server/sqlite3/storage.ide-shm
+.vs/TaleSpireGrabDropPlugin/v15/Server/sqlite3/storage.ide
+.vs/TaleSpireGrabDropPlugin/v15/Server/sqlite3/db.lock
+.vs/TaleSpireGrabDropPlugin/v15/.suo

--- a/TaleSpireGrabDropPlugin/GrabDropPlugin.cs
+++ b/TaleSpireGrabDropPlugin/GrabDropPlugin.cs
@@ -2,7 +2,6 @@
 using BepInEx;
 using Bounce.Unmanaged;
 using System.Collections.Generic;
-using System.Linq;
 using System;
 using BepInEx.Configuration;
 
@@ -47,11 +46,11 @@ namespace LordAshes
                 {
                     if (actOnMini.Value)
                     {
-                        StatMessaging.SetInfo(radialCreature, GrabDropPlugin.Guid, "Grab," + LocalClient.SelectedCreatureId.ToString());
+                        StatMessaging.SetInfo(radialCreature, GrabDropPlugin.Guid + ".grab", LocalClient.SelectedCreatureId.ToString());
                     }
                     else
                     {
-                        StatMessaging.SetInfo(LocalClient.SelectedCreatureId, GrabDropPlugin.Guid, "Grab," + radialCreature.ToString());
+                        StatMessaging.SetInfo(LocalClient.SelectedCreatureId, GrabDropPlugin.Guid + ".grab", radialCreature.ToString());
                     }
                 },
                 Icon = FileAccessPlugin.Image.LoadSprite("Grab.png"),
@@ -66,11 +65,11 @@ namespace LordAshes
                 {
                     if (actOnMini.Value)
                     {
-                        StatMessaging.SetInfo(radialCreature, GrabDropPlugin.Guid, "Drop,");
+                        StatMessaging.SetInfo(radialCreature, GrabDropPlugin.Guid + ".drop", LocalClient.SelectedCreatureId.ToString());
                     }
                     else
                     {
-                        StatMessaging.SetInfo(LocalClient.SelectedCreatureId, GrabDropPlugin.Guid, "Drop,"+radialCreature.ToString());
+                        StatMessaging.SetInfo(LocalClient.SelectedCreatureId, GrabDropPlugin.Guid + ".drop", radialCreature.ToString());
                     }
                 },
                 Icon = FileAccessPlugin.Image.LoadSprite("Drop.png"),
@@ -78,50 +77,112 @@ namespace LordAshes
                 CloseMenuOnActivate = true
             }, Reporter);
 
-            // Subscribe to grab and drop requests
-            StatMessaging.Subscribe(GrabDropPlugin.Guid, (changes) =>
+            // Create safe Kill menu entry      
+            RadialUI.RadialUIPlugin.AddOnRemoveSubmenuKill(Guid + ".removeKill", "Kill Creature"); //Remove vanilla TS Kill Menu
+            RadialUI.RadialUIPlugin.AddOnSubmenuKill(Guid + ".safeKill", new MapMenu.ItemArgs //Replace with GrabDrop safe alternative
+            {
+                Action = (mmi, obj) =>
+                {
+                    CreatureBoardAsset asset;
+                    CreaturePresenter.TryGetAsset(radialCreature, out asset);
+
+                    if (asset != null)
+                    {
+                        try
+                        {
+                            Debug.Log("Beginning GrabDrop Safe Kill");
+                            List<Transform> tempTransformList = new List<Transform>();
+
+                            //Find certain transforms to preserve
+                            foreach (Transform child in asset.gameObject.transform.Children())
+                            {
+                                if (child.name == "MoveableOffset" || child.gameObject.name.StartsWith("Custom:") /*|| child.gameObject.name.Contains("(Clone)")*/)
+                                {
+                                    //Debug.Log("Preserving '" + child.name + "' transform for safe delete");
+                                    tempTransformList.Add(child);
+                                }
+                            }
+
+                            //It's imperative we remove the parent child relationship with any dragged creatures before deleting the parent
+                            asset.gameObject.transform.DetachChildren();  
+
+                            //Certain transforms must be preserved to be gracefully disposed of by the engine when the parent object is deleted
+                            if (tempTransformList.Count > 0)
+                            {   
+                                foreach (Transform tempTransform in tempTransformList)
+                                {
+                                    tempTransform.SetParent(asset.gameObject.transform);
+                                }
+                            }
+
+                            asset.Creature.BoardAsset.RequestDelete(); //Perform the actual deletion
+                            Debug.Log("GrabDrop Safe Kill Complete");
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.LogException(ex);
+                        }
+                    }
+                },
+                Icon = Icons.GetIconSprite("remove"),
+                Title = "Kill Creature",
+                CloseMenuOnActivate = true
+            }, Reporter);
+
+            // Subscribe to grab requests
+            StatMessaging.Subscribe(GrabDropPlugin.Guid + ".grab", (changes) =>
             {
                 foreach (StatMessaging.Change change in changes)
                 {
                     try
                     {
-                        string[] values = change.value.Split(',');
-
-                        if (values[0] == "Grab")
+                        // Grab
+                        CreatureBoardAsset asset;
+                        CreaturePresenter.TryGetAsset(change.cid, out asset);
+                        if (asset != null)
                         {
-                            // Grab
-                            CreatureBoardAsset asset;
-                            CreaturePresenter.TryGetAsset(change.cid, out asset);
-                            if (asset != null)
+                            CreatureBoardAsset child;
+                            CreaturePresenter.TryGetAsset(new CreatureGuid(change.value), out child);
+                            if (child != null)
                             {
-                                CreatureBoardAsset child;
-                                CreaturePresenter.TryGetAsset(new CreatureGuid(values[1]), out child);
-                                if (child != null)
-                                {
-                                    Debug.Log(StatMessaging.GetCreatureName(asset.Creature) + " grabs '" + child.Creature.Name + "'");
-                                    child.transform.SetParent(asset.transform);
-                                }
+                                Debug.Log(StatMessaging.GetCreatureName(asset.Creature) + " grabs '" + child.Creature.Name + "'");
+                                child.transform.SetParent(asset.transform);
                             }
                         }
-                        else if (values[0] == "Drop")
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogException(ex);
+                    }
+                }
+            });
+
+            // Subscribe to drop requests
+            StatMessaging.Subscribe(GrabDropPlugin.Guid + ".drop", (changes) =>
+            {
+                foreach (StatMessaging.Change change in changes)
+                {
+                    try
+                    {
+                        // Drop
+                        CreatureBoardAsset asset;
+                        CreaturePresenter.TryGetAsset(change.cid, out asset);
+                        if (asset != null)
                         {
-                            // Drop
-                            CreatureBoardAsset asset;
-                            CreaturePresenter.TryGetAsset(change.cid, out asset);
+                            CreatureBoardAsset droppedChild;
+                            CreaturePresenter.TryGetAsset(new CreatureGuid(change.value), out droppedChild);
                             foreach (Transform child in asset.transform.Children())
                             {
-                                if ((child.gameObject.name.StartsWith("Custom:")) || (child.gameObject.name.Contains("(Clone)")))
+                                if (child.gameObject == droppedChild.gameObject)
                                 {
-                                    Debug.Log(StatMessaging.GetCreatureName(asset.Creature) + " drops '" + child.gameObject.name + "'");
+                                    Debug.Log(StatMessaging.GetCreatureName(asset.Creature) + " drops '" + StatMessaging.GetCreatureName(droppedChild.Creature) + "'");
                                     child.transform.SetParent(null);
+                                    break;
                                 }
                             }
                         }
-                        else
-                        {
-                            Debug.Log("Error: Unknown value prefix in GrabDrop while resolving action: " + values[0]);
-                        }
-                    }catch(Exception ex)
+                    }
+                    catch (Exception ex)
                     {
                         Debug.LogException(ex);
                     }


### PR DESCRIPTION
1) Fixed issues relating to deleting a mini who was the grabbing parent of other minis.

2) Tested and ensured compatibility with CMP.

3) Refined drop process to allow dropping individual minis from a parent via the RadialUI menu on the target child.

4) One mini may now grab more than one other mini at a time.

-A